### PR TITLE
Improving build commands implementation

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -43,7 +43,7 @@ spec:
           scope: RUN_TIME
         - key: WEB3_SMART_CONTRACT_ADDRESS
           scope: RUN_TIME
-          value: 0xaDC28cac9c1d53cC7457b11CC9423903dc09DDDc
+          value: 0xYOUR_CONTRACT_ADDRESS
         - key: WEB3_HTTP_ENDPOINT
           scope: RUN_TIME
           type: SECRET

--- a/.env
+++ b/.env
@@ -36,10 +36,10 @@ S3_FS_DRIVER_OBJECTS_KEY_PREFIX=
 ENV_TOTAL_SUPPLY=8
 
 # Used by the OpenSeaStatsProvider
-OPEN_SEA_COLLECTION_SLUG=sketchy-ape-book-club
+OPEN_SEA_COLLECTION_SLUG=open-sea-collection-slug
 
 # Used by the Web3Provider
-WEB3_SMART_CONTRACT_ADDRESS=0xaDC28cac9c1d53cC7457b11CC9423903dc09DDDc
+WEB3_SMART_CONTRACT_ADDRESS=0xYOUR_CONTRACT_ADDRESS
 WEB3_HTTP_ENDPOINT=https://mainnet.infura.io/v3/YOUR_PROJECT_ID_HERE
 
 ###> symfony/framework-bundle ###

--- a/README.md
+++ b/README.md
@@ -12,4 +12,5 @@ I suggest deploying this app using [DigitalOcean](https://m.do.co/c/bcc172152095
 By using my link you will be given a 100$ credit on DigitalOcean: https://m.do.co/c/bcc172152095
 
 You can also do a one-click deployment on DigitalOcean:
+
 [![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/liarco-network/safe-nft-metadata-provider/tree/main)

--- a/src/Command/BuildMetadataCommand.php
+++ b/src/Command/BuildMetadataCommand.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace App\Command;
 
 use App\Service\CollectionManager;
-use Nette\Utils\Json;
 use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -22,7 +21,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @author Marco Lipparini <developer@liarco.net>
@@ -38,14 +36,8 @@ class BuildMetadataCommand extends Command
      */
     private const URI_PREFIX = 'uri-prefix';
 
-    /**
-     * @var string
-     */
-    private const OUTPUT_PATH = 'output-path';
-
     public function __construct(
         private readonly CollectionManager $collectionManager,
-        private readonly Filesystem $filesystem,
         string $name = null,
     ) {
         parent::__construct($name);
@@ -60,54 +52,33 @@ class BuildMetadataCommand extends Command
                 'The URI prefix where the assets have been uploaded to',
             )
         ;
-
-        $this
-            ->addArgument(
-                self::OUTPUT_PATH,
-                InputArgument::REQUIRED,
-                'The output path for the new files (local paths only)',
-            )
-        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $symfonyStyle = new SymfonyStyle($input, $output);
         $uriPrefix = $input->getArgument(self::URI_PREFIX);
-        $outputPath = $input->getArgument(self::OUTPUT_PATH);
-
-        if (! is_string($outputPath) || strlen($outputPath) <= 0) {
-            throw new RuntimeException('Invalid output path.');
-        }
 
         if (! is_string($uriPrefix) || strlen($uriPrefix) <= 0) {
             throw new RuntimeException('Invalid URI prefix.');
         }
 
-        if (is_dir($outputPath)) {
-            if (! $symfonyStyle->confirm(
-                "I'm about to delete the output directory and its content. Are you sure?",
-                false,
-            )) {
-                $symfonyStyle->warning('Aborting...');
+        if (! $symfonyStyle->confirm(
+            "I'm about to delete the shuffled metadata directory and its content. Are you sure?",
+            false,
+        )) {
+            $symfonyStyle->warning('Aborting...');
 
-                return Command::SUCCESS;
-            }
-
-            $this->filesystem->remove($outputPath);
-            $this->filesystem->mkdir($outputPath);
+            return Command::SUCCESS;
         }
+
+        $this->collectionManager->clearShuffledMetadata();
 
         $symfonyStyle->progressStart($this->collectionManager->getMaxTokenId());
 
         foreach (range(1, $this->collectionManager->getMaxTokenId()) as $tokenId) {
-            $this->filesystem->dumpFile(
-                $outputPath.'/'.$tokenId.'.json',
-                Json::encode(
-                    $this->collectionManager->getMetadata($tokenId, trim($uriPrefix, '/').'/'.$tokenId.'.json'),
-                    Json::PRETTY,
-                ),
-            );
+            $this->collectionManager->storeShuffledMetadata($tokenId, trim($uriPrefix, '/'));
+            gc_collect_cycles();
 
             $symfonyStyle->progressAdvance();
         }

--- a/src/Contract/CollectionFilesystemDriverInterface.php
+++ b/src/Contract/CollectionFilesystemDriverInterface.php
@@ -23,12 +23,12 @@ interface CollectionFilesystemDriverInterface
     /**
      * @var string
      */
-    final public const ASSETS_PATH = '/assets';
+    final public const METADATA_PATH = '/metadata';
 
     /**
      * @var string
      */
-    final public const METADATA_PATH = '/metadata';
+    final public const ASSETS_PATH = '/assets';
 
     /**
      * @var string
@@ -49,6 +49,16 @@ interface CollectionFilesystemDriverInterface
      * @var string
      */
     final public const MAPPING_PATH = '/mapping.json';
+
+    /**
+     * @var string
+     */
+    final public const SHUFFLED_METADATA_PATH = '/shuffled/metadata';
+
+    /**
+     * @var string
+     */
+    final public const SHUFFLED_ASSETS_PATH = '/shuffled/assets';
 
     public function getAssetsExtension(): string;
 
@@ -82,4 +92,15 @@ interface CollectionFilesystemDriverInterface
      * @param int[] $newShuffleMapping
      */
     public function storeNewShuffleMapping(array $newShuffleMapping): void;
+
+    public function clearShuffledMetadata(): void;
+
+    public function clearShuffledAssets(): void;
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function storeShuffledMetadata(int $tokenId, array $metadata): void;
+
+    public function storeShuffledAsset(int $tokenId, SplFileInfo $originalAsset): void;
 }

--- a/src/FilesystemDriver/LocalFilesystemDriver.php
+++ b/src/FilesystemDriver/LocalFilesystemDriver.php
@@ -129,4 +129,34 @@ final class LocalFilesystemDriver implements CollectionFilesystemDriverInterface
     {
         FileSystem::write($this->localCollectionPath.self::MAPPING_PATH, Json::encode($newShuffleMapping));
     }
+
+    public function clearShuffledMetadata(): void
+    {
+        FileSystem::delete($this->localCollectionPath.self::SHUFFLED_METADATA_PATH);
+    }
+
+    public function clearShuffledAssets(): void
+    {
+        FileSystem::delete($this->localCollectionPath.self::SHUFFLED_ASSETS_PATH);
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function storeShuffledMetadata(int $tokenId, array $metadata): void
+    {
+        FileSystem::write(
+            $this->localCollectionPath.self::SHUFFLED_METADATA_PATH.'/'.$tokenId.'.json',
+            Json::encode($metadata, Json::PRETTY),
+            null,
+        );
+    }
+
+    public function storeShuffledAsset(int $tokenId, SplFileInfo $originalAsset): void
+    {
+        FileSystem::copy(
+            $originalAsset->getPathname(),
+            $this->localCollectionPath.self::SHUFFLED_ASSETS_PATH.'/'.$tokenId.'.'.$this->assetsExtension,
+        );
+    }
 }

--- a/src/FilesystemDriver/S3FilesystemDriver.php
+++ b/src/FilesystemDriver/S3FilesystemDriver.php
@@ -152,6 +152,36 @@ final class S3FilesystemDriver implements CollectionFilesystemDriverInterface
         FileSystem::write($this->buildS3Path(self::MAPPING_PATH), Json::encode($newShuffleMapping), null);
     }
 
+    public function clearShuffledMetadata(): void
+    {
+        FileSystem::delete($this->buildS3Path(self::SHUFFLED_METADATA_PATH));
+    }
+
+    public function clearShuffledAssets(): void
+    {
+        FileSystem::delete($this->buildS3Path(self::SHUFFLED_ASSETS_PATH));
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function storeShuffledMetadata(int $tokenId, array $metadata): void
+    {
+        FileSystem::write(
+            $this->buildS3Path(self::SHUFFLED_METADATA_PATH.'/'.$tokenId.'.json'),
+            Json::encode($metadata, Json::PRETTY),
+            null,
+        );
+    }
+
+    public function storeShuffledAsset(int $tokenId, SplFileInfo $originalAsset): void
+    {
+        FileSystem::copy(
+            $originalAsset->getPathname(),
+            $this->buildS3Path(self::SHUFFLED_ASSETS_PATH.'/'.$tokenId.'.'.$this->assetsExtension),
+        );
+    }
+
     private function buildS3Path(string $relativePath): string
     {
         $keyPrefix = empty($this->objectsKeyPrefix) ? '' : trim($this->objectsKeyPrefix, '/').'/';

--- a/src/Service/CollectionManager.php
+++ b/src/Service/CollectionManager.php
@@ -143,6 +143,29 @@ final class CollectionManager
         return $this->collectionFilesystemDriver->getShuffleMapping();
     }
 
+    public function clearShuffledMetadata(): void
+    {
+        $this->collectionFilesystemDriver->clearShuffledMetadata();
+    }
+
+    public function clearShuffledAssets(): void
+    {
+        $this->collectionFilesystemDriver->clearShuffledAssets();
+    }
+
+    public function storeShuffledMetadata(int $tokenId, string $uriPrefix): void
+    {
+        $this->collectionFilesystemDriver->storeShuffledMetadata(
+            $tokenId,
+            $this->getMetadata($tokenId, $uriPrefix.'/'.$tokenId.'.json'),
+        );
+    }
+
+    public function storeShuffledAsset(int $tokenId): void
+    {
+        $this->collectionFilesystemDriver->storeShuffledAsset($tokenId, $this->getAssetFileInfo($tokenId));
+    }
+
     private function getMappedTokenId(int $tokenId): int
     {
         $shuffleMapping = $this->collectionFilesystemDriver->getShuffleMapping();


### PR DESCRIPTION
The new implementation uses the `CollectionFilesystemDriverInterface` in order to build the shuffled collection to the same storage as the original one for a better user experience.