### PR TITLE
Improving export performances

### DIFF
--- a/src/Contract/CollectionFilesystemDriverInterface.php
+++ b/src/Contract/CollectionFilesystemDriverInterface.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace App\Contract;
 
-use SplFileInfo;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @author Marco Lipparini <developer@liarco.net>
@@ -69,14 +69,14 @@ interface CollectionFilesystemDriverInterface
      */
     public function getMetadata(int $tokenId): array;
 
-    public function getAssetFileInfo(int $tokenId): SplFileInfo;
+    public function getAssetResponse(int $tokenId): Response;
 
     /**
      * @return array<string, mixed>
      */
     public function getHiddenMetadata(): array;
 
-    public function getHiddenAssetFileInfo(): SplFileInfo;
+    public function getHiddenAssetResponse(): Response;
 
     /**
      * @return object[]
@@ -102,5 +102,5 @@ interface CollectionFilesystemDriverInterface
      */
     public function storeExportedMetadata(int $tokenId, array $metadata): void;
 
-    public function storeExportedAsset(int $tokenId, SplFileInfo $originalAsset): void;
+    public function storeExportedAsset(int $sourceTokenId, int $targetTokenId): void;
 }

--- a/src/Controller/AssetController.php
+++ b/src/Controller/AssetController.php
@@ -16,7 +16,6 @@ namespace App\Controller;
 use App\Config\RouteName;
 use App\Contract\AbstractNftController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -37,12 +36,8 @@ final class AssetController extends AbstractNftController
             throw $this->createNotFoundException();
         }
 
-        return $this
-            ->file(
-                $this->collectionManager->getAssetFileInfo($tokenId),
-                null,
-                ResponseHeaderBag::DISPOSITION_INLINE,
-            )
+        return $this->collectionManager
+            ->getAssetResponse($tokenId)
             ->setPublic()
             ->setMaxAge($this->getDefaultCacheExpiration())
         ;

--- a/src/Controller/HiddenAssetController.php
+++ b/src/Controller/HiddenAssetController.php
@@ -16,7 +16,6 @@ namespace App\Controller;
 use App\Config\RouteName;
 use App\Contract\AbstractNftController;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -33,8 +32,7 @@ final class HiddenAssetController extends AbstractNftController
 {
     public function __invoke(): Response
     {
-        return $this
-            ->file($this->collectionManager->getHiddenAssetFileInfo(), null, ResponseHeaderBag::DISPOSITION_INLINE)
+        return $this->collectionManager->getHiddenAssetResponse()
             ->setPublic()
             ->setMaxAge($this->getDefaultCacheExpiration())
         ;

--- a/src/FilesystemDriver/S3/FileObject.php
+++ b/src/FilesystemDriver/S3/FileObject.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Safe NFT Metadata Provider package.
+ *
+ * (c) Marco Lipparini <developer@liarco.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\FilesystemDriver\S3;
+
+/**
+ * @author Marco Lipparini <developer@liarco.net>
+ */
+final class FileObject
+{
+    public function __construct(
+        public string $contentType,
+        public string $contents,
+    ) {
+    }
+}


### PR DESCRIPTION
By using the AWS SDK functions directly instead of the PHP stream wrapper we get ~50 exports per second instead of just 1 (under the same conditions).