### PR TITLE
Fixing DigitalOcean template

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -27,7 +27,7 @@ spec:
           value: gif
         - key: METADATA_TEMPLATE
           scope: RUN_TIME
-          value: null
+          value: 'null'
         - key: CACHE_EXPIRATION
           scope: RUN_TIME
           value: '600'


### PR DESCRIPTION
The "null" value in the YAML template must be a string, otherwise DigitalOcean is going to use an empty string.