### PR TITLE
Enabling DigitalOcean deployment without advanced GitHub authentication

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -57,10 +57,9 @@ spec:
           scope: RUN_TIME
           type: SECRET
           value: https://mainnet.infura.io/v3/YOUR_PROJECT_ID_HERE
-      github:
+      git:
         branch: main
-        deploy_on_push: true
-        repo: hashlips-lab/safe-nft-metadata-provider
+        repo_clone_url: https://github.com/hashlips-lab/safe-nft-metadata-provider.git
       http_port: 8080
       instance_count: 1
       instance_size_slug: basic-xxs

--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ By using the following referral link you will be given a 100$ credit on DigitalO
 
 You can also do a one-click deployment on DigitalOcean:
 
-[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/hashlips-lab/safe-nft-metadata-provider/tree/main)
+[![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/hashlips-lab/safe-nft-metadata-provider/tree/main&refcode=bcc172152095)


### PR DESCRIPTION
Replacing the `github` key with `git` bypasses GitHub account verification.