### PR TITLE
Fixing assets extension in exported metadata

### DIFF
--- a/src/Service/CollectionManager.php
+++ b/src/Service/CollectionManager.php
@@ -166,7 +166,7 @@ final class CollectionManager
     {
         $this->collectionFilesystemDriver->storeExportedMetadata(
             $tokenId,
-            $this->getMetadata($tokenId, $uriPrefix.'/'.$tokenId.'.json'),
+            $this->getMetadata($tokenId, $uriPrefix.'/'.$tokenId.'.'.$this->collectionFilesystemDriver->getAssetsExtension()),
         );
     }
 

--- a/src/Service/CollectionManager.php
+++ b/src/Service/CollectionManager.php
@@ -166,7 +166,10 @@ final class CollectionManager
     {
         $this->collectionFilesystemDriver->storeExportedMetadata(
             $tokenId,
-            $this->getMetadata($tokenId, $uriPrefix.'/'.$tokenId.'.'.$this->collectionFilesystemDriver->getAssetsExtension()),
+            $this->getMetadata(
+                $tokenId,
+                $uriPrefix.'/'.$tokenId.'.'.$this->collectionFilesystemDriver->getAssetsExtension(),
+            ),
         );
     }
 


### PR DESCRIPTION
The `nft:export-metadata` command was exporting the metadata appending a static `.json` string as extension on the `image` field.